### PR TITLE
Adding cone search

### DIFF
--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -527,7 +527,8 @@ class Database:
     def cone_search(self, ra, dec, radius=10, output_table=None, fmt='table',
                     coordinate_table=None, ra_col='ra', dec_col='dec'):
         """
-        Perform a cone search of the given object against the coordinate table and return the output table
+        Perform a cone search of the given coordinates and return the specifed output table.
+        RA/Dec should be in degrees, but radius is expected in arcseconds.
 
         Parameters
         ----------

--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -431,7 +431,7 @@ class Database:
             Dictionary of tables to search for name information. Should be of the form table name: column name list.
             Default: {'Sources': ['source', 'shortname'], 'Names': 'other_name'}
         fmt : str
-            Format to return results in (pandas, astropy/table, default). Default is atropy table
+            Format to return results in (pandas, astropy/table, default). Default is astropy table
         fuzzy_search : bool
             Flag to perform partial searches on provided names (default: True)
         verbose : bool

--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -526,18 +526,15 @@ class Database:
 
         return self._handle_format(temp, fmt)
 
-    def cone_search(self, ra, dec, radius=Quantity(10, unit='arcsec'), output_table=None, fmt='table',
+    def query_region(self, target_coords, radius=Quantity(10, unit='arcsec'), output_table=None, fmt='table',
                     coordinate_table=None, ra_col='ra', dec_col='dec', frame='icrs', unit='deg'):
         """
-        Perform a cone search of the given coordinates and return the specifed output table.
-        RA/Dec should be in the same units as the database, radius by default is expected in arcseconds.
+        Perform a cone search of the given coordinates and return the specified output table.
 
         Parameters
         ----------
-        ra : float
-            RA value to search around in degrees
-        dec : float
-            Dec value to search around in degrees
+        target_coords : SkyCoord
+            Astropy SkyCoord object of coordinates to search around
         radius : Quantity or float
             Radius as an astropy Quantity object in which to search for objects.
             If not a Quantity will convert to one assuming units are arcseconds. Default: 10 arcseconds
@@ -592,9 +589,8 @@ class Database:
         df = df[~mask]
 
         # Native use of astropy SkyCoord objects here
-        target_center = SkyCoord(ra, dec, frame=frame, unit=unit)
         coord_list = SkyCoord(df['ra'].tolist(), df['dec'].tolist(), frame=frame, unit=unit)
-        sep_list = coord_list.separation(target_center)  # sky separations for each db object against target position
+        sep_list = coord_list.separation(target_coords)  # sky separations for each db object against target position
         good = sep_list <= radius
 
         if sum(good) > 0:

--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -541,7 +541,7 @@ class Database:
         output_table : str
             Name of table to match. Default: primary table (eg, Sources)
         fmt : str
-            Format to return results in (pandas, astropy/table, default). Default is atropy table
+            Format to return results in (pandas, astropy/table, default). Default is astropy table
         coordinate_table : str
             Table to use for coordinates. Default: primary table (eg, Sources)
         ra_col : str

--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -564,17 +564,17 @@ class Database:
         match_column = self._foreign_key
         if output_table == self._primary_table:
             match_column = self._primary_table_key
-        coordinate_match_column = self._foreign_key
-        if coordinate_table == self._primary_table:
-            coordinate_match_column = self._primary_table_key
 
         # Grab the specified coordinate table (Sources by default) to construct SkyCoord objects
-        # This is adapted from the original astrodbkit code
         if coordinate_table is None:
             coordinate_table = self._primary_table
         if coordinate_table not in self.metadata.tables:
             raise RuntimeError(f'Table {coordinate_table} is not in the database')
+        coordinate_match_column = self._foreign_key
+        if coordinate_table == self._primary_table:
+            coordinate_match_column = self._primary_table_key
 
+        # This is adapted from the original astrodbkit code
         df = self.query(self.metadata.tables[coordinate_table]).pandas()
         df[['ra', 'dec']] = df[[ra_col, dec_col]].apply(pd.to_numeric)  # convert everything to floats
         mask = df['ra'].isnull()

--- a/astrodbkit2/tests/test_astrodb.py
+++ b/astrodbkit2/tests/test_astrodb.py
@@ -111,6 +111,11 @@ def test_add_data(db):
     spt_data[0]['regime'] = 'infrared'
     db.SpectralTypes.insert().execute(spt_data)
 
+    # Adding source with no ra/dec to test cone search
+    sources_data = [{'source': 'Third star',
+                     'reference': 'Schm10'}]
+    db.Sources.insert().execute(sources_data)
+
 
 def test_add_table_data(db):
     # Test the add_table_data method
@@ -147,7 +152,7 @@ def test_query_data(db):
     # Perform some example queries and confirm the results
     assert db.query(db.Publications).count() == 2
     assert db.query(db.Photometry).count() == 3
-    assert db.query(db.Sources).count() == 2
+    assert db.query(db.Sources).count() == 3
     assert db.query(db.Sources.c.source).limit(1).all()[0][0] == '2MASS J13571237+1428398'
 
 
@@ -206,7 +211,7 @@ def test_sql_query(db):
     # Perform direct SQLite queries
     # Includes testing of _handle_format implicitly
     t = db.sql_query('SELECT * FROM Sources', fmt='default')
-    assert len(t) == 2
+    assert len(t) == 3
     assert isinstance(t, list)
     t = db.sql_query('SELECT * FROM Sources', fmt='astropy')
     assert isinstance(t, Table)
@@ -226,7 +231,7 @@ def test_sql_query(db):
 def test_query_formats(db):
     # Check that the query subclass is working properly
     t = db.query(db.Sources).astropy()
-    assert len(t) == 2
+    assert len(t) == 3
     assert isinstance(t, Table)
     t = db.query(db.Sources).table()
     assert isinstance(t, Table)
@@ -234,7 +239,7 @@ def test_query_formats(db):
     assert len(t) == 0
     assert isinstance(t, Table)
     t = db.query(db.Sources).pandas()
-    assert len(t) == 2
+    assert len(t) == 3
     assert isinstance(t, pd.DataFrame)
     t = db.query(db.Instruments).pandas()
     assert len(t) == 0
@@ -336,7 +341,7 @@ def test_load_database(db, db_dir):
     db.load_database(db_dir, verbose=True)
     assert db.query(db.Publications).count() == 2
     assert db.query(db.Photometry).count() == 3
-    assert db.query(db.Sources).count() == 2
+    assert db.query(db.Sources).count() == 3
     assert db.query(db.Sources.c.source).limit(1).all()[0][0] == '2MASS J13571237+1428398'
 
     # Clear temporary directory and files
@@ -355,7 +360,7 @@ def test_copy_database_schema():
     db2 = Database(connection_2)
     assert db2
     assert 'source' in [c.name for c in db2.Sources.columns]
-    assert db2.query(db2.Sources).count() == 2
+    assert db2.query(db2.Sources).count() == 3
     assert db2.query(db2.Publications).count() == 2
     assert db2.query(db2.Sources.c.source).limit(1).all()[0][0] == '2MASS J13571237+1428398'
 

--- a/astrodbkit2/tests/test_astrodb.py
+++ b/astrodbkit2/tests/test_astrodb.py
@@ -7,6 +7,7 @@ import io
 import pandas as pd
 from sqlalchemy.exc import IntegrityError
 from astropy.table import Table
+from astropy.units.quantity import Quantity
 from astropy.io import ascii
 from astrodbkit2.astrodb import Database, create_database, Base, copy_database_schema
 from astrodbkit2.schema_example import *
@@ -193,7 +194,15 @@ def test_cone_search(db):
     assert len(t) == 1
     assert t['source'][0] == '2MASS J13571237+1428398', 'Did not find correct source'
 
+    t = db.cone_search(ra=209.301675, dec=14.477722, radius=Quantity(20, unit='arcsec'))
+    assert len(t) == 1
+    assert t['source'][0] == '2MASS J13571237+1428398', 'Did not find correct source'
+
     t = db.cone_search(209.302, 14.478, radius=60.)
+    print(t)
+    assert len(t) == 1, 'Did not find correct source in 1 arcmin search'
+
+    t = db.cone_search(209.302, 14.478, radius=Quantity(1., unit='arcmin'))
     print(t)
     assert len(t) == 1, 'Did not find correct source in 1 arcmin search'
 

--- a/astrodbkit2/tests/test_astrodb.py
+++ b/astrodbkit2/tests/test_astrodb.py
@@ -7,6 +7,7 @@ import io
 import pandas as pd
 from sqlalchemy.exc import IntegrityError
 from astropy.table import Table
+from astropy.coordinates import SkyCoord
 from astropy.units.quantity import Quantity
 from astropy.io import ascii
 from astrodbkit2.astrodb import Database, create_database, Base, copy_database_schema
@@ -186,34 +187,34 @@ def test_search_object(mock_simbad, db):
         t = db.search_object('fake', table_names={'NOTABLE': ['nocolumn']})
 
 
-def test_cone_search(db):
-    t = db.cone_search(0, 0)
+def test_query_region(db):
+    t = db.query_region(SkyCoord(0, 0, frame='icrs', unit='deg'))
     assert len(t) == 0, 'Found source around 0,0 when there should be none'
 
-    t = db.cone_search(ra=209.301675, dec=14.477722)
+    t = db.query_region(SkyCoord(209.301675, 14.477722, frame='icrs', unit='deg'))
     assert len(t) == 1
     assert t['source'][0] == '2MASS J13571237+1428398', 'Did not find correct source'
 
-    t = db.cone_search(ra=209.301675, dec=14.477722, radius=Quantity(20, unit='arcsec'))
+    t = db.query_region(SkyCoord(209.301675, 14.477722, frame='icrs', unit='deg'), radius=Quantity(20, unit='arcsec'))
     assert len(t) == 1
     assert t['source'][0] == '2MASS J13571237+1428398', 'Did not find correct source'
 
-    t = db.cone_search(209.302, 14.478, radius=60.)
+    t = db.query_region(SkyCoord(209.302, 14.478, frame='icrs', unit='deg'), radius=60.)
     print(t)
     assert len(t) == 1, 'Did not find correct source in 1 arcmin search'
 
-    t = db.cone_search(209.302, 14.478, radius=Quantity(1., unit='arcmin'))
+    t = db.query_region(SkyCoord(209.302, 14.478, frame='icrs', unit='deg'), radius=Quantity(1., unit='arcmin'))
     print(t)
     assert len(t) == 1, 'Did not find correct source in 1 arcmin search'
 
-    t = db.cone_search(ra=209.301675, dec=14.477722, output_table='Photometry')
+    t = db.query_region(SkyCoord(209.301675, 14.477722, frame='icrs', unit='deg'), output_table='Photometry')
     assert len(t) == 3, 'Did not return 3 photometry values'
 
     # Two searches providing tables that do not exist
     with pytest.raises(RuntimeError):
-        t = db.cone_search(ra=209, dec=14, output_table='NOTABLE')
+        t = db.query_region(SkyCoord(209, 14, frame='icrs', unit='deg'), output_table='NOTABLE')
     with pytest.raises(RuntimeError):
-        t = db.cone_search(ra=209, dec=14, coordinate_table='NOTABLE')
+        t = db.query_region(SkyCoord(209, 14, frame='icrs', unit='deg'), coordinate_table='NOTABLE')
 
 
 def test_sql_query(db):

--- a/astrodbkit2/tests/test_astrodb.py
+++ b/astrodbkit2/tests/test_astrodb.py
@@ -182,7 +182,7 @@ def test_search_object(mock_simbad, db):
 
 def test_cone_search(db):
     t = db.cone_search(0, 0)
-    assert len(t) == 0, 'Found source around 0,0 when there should be any'
+    assert len(t) == 0, 'Found source around 0,0 when there should be none'
 
     t = db.cone_search(ra=209.301675, dec=14.477722)
     assert len(t) == 1

--- a/astrodbkit2/tests/test_astrodb.py
+++ b/astrodbkit2/tests/test_astrodb.py
@@ -180,6 +180,28 @@ def test_search_object(mock_simbad, db):
         t = db.search_object('fake', table_names={'NOTABLE': ['nocolumn']})
 
 
+def test_cone_search(db):
+    t = db.cone_search(0, 0)
+    assert len(t) == 0, 'Found source around 0,0 when there should be any'
+
+    t = db.cone_search(ra=209.301675, dec=14.477722)
+    assert len(t) == 1
+    assert t['source'][0] == '2MASS J13571237+1428398', 'Did not find correct source'
+
+    t = db.cone_search(209.302, 14.478, radius=60.)
+    print(t)
+    assert len(t) == 1, 'Did not find correct source in 1 arcmin search'
+
+    t = db.cone_search(ra=209.301675, dec=14.477722, output_table='Photometry')
+    assert len(t) == 3, 'Did not return 3 photometry values'
+
+    # Two searches providing tables that do not exist
+    with pytest.raises(RuntimeError):
+        t = db.cone_search(ra=209, dec=14, output_table='NOTABLE')
+    with pytest.raises(RuntimeError):
+        t = db.cone_search(ra=209, dec=14, coordinate_table='NOTABLE')
+
+
 def test_sql_query(db):
     # Perform direct SQLite queries
     # Includes testing of _handle_format implicitly

--- a/astrodbkit2/tests/test_utils.py
+++ b/astrodbkit2/tests/test_utils.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from decimal import Decimal
 from io import StringIO
 from astropy.table import Table
-from astrodbkit2.utils import json_serializer, get_simbad_names, _name_formatter, datetime_json_parser
+from astrodbkit2.utils import json_serializer, get_simbad_names, _name_formatter, datetime_json_parser, \
+    angular_separation
 try:
     import mock
 except ImportError:
@@ -58,3 +59,12 @@ def test_get_simbad_names(mock_simbad):
     t = get_simbad_names('WISEU J005559.88+594745.0')
     assert len(t) == 1
     assert t[0] == 'WISEU J005559.88+594745.0'
+
+
+@pytest.mark.parametrize('test_input, expected', [
+    ((0, 0), 147.60),
+    ((209.3, 14.4), 0.07774),
+])
+def test_angular_separation(test_input, expected):
+    data_dict = {'ra': 209.301675, 'dec': 14.477722}
+    assert angular_separation(data_dict, *test_input) == pytest.approx(expected, 1/60.)

--- a/astrodbkit2/tests/test_utils.py
+++ b/astrodbkit2/tests/test_utils.py
@@ -6,8 +6,7 @@ from datetime import datetime
 from decimal import Decimal
 from io import StringIO
 from astropy.table import Table
-from astrodbkit2.utils import json_serializer, get_simbad_names, _name_formatter, datetime_json_parser, \
-    angular_separation
+from astrodbkit2.utils import json_serializer, get_simbad_names, _name_formatter, datetime_json_parser
 try:
     import mock
 except ImportError:
@@ -59,12 +58,3 @@ def test_get_simbad_names(mock_simbad):
     t = get_simbad_names('WISEU J005559.88+594745.0')
     assert len(t) == 1
     assert t[0] == 'WISEU J005559.88+594745.0'
-
-
-@pytest.mark.parametrize('test_input, expected', [
-    ((0, 0), 147.60),
-    ((209.3, 14.4), 0.07774),
-])
-def test_angular_separation(test_input, expected):
-    data_dict = {'ra': 209.301675, 'dec': 14.477722}
-    assert angular_separation(data_dict, *test_input) == pytest.approx(expected, 1/60.)

--- a/astrodbkit2/utils.py
+++ b/astrodbkit2/utils.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 from astroquery.simbad import Simbad
 
-__all__ = ['json_serializer', 'get_simbad_names', 'angular_separation']
+__all__ = ['json_serializer', 'get_simbad_names']
 
 
 def deprecated_alias(**aliases):
@@ -121,39 +121,3 @@ def get_simbad_names(name):
     else:
         print(f'No Simbad match for {name}')
         return [name]
-
-
-def angular_separation(row, ra1, dec1):
-    """
-    Calculate angular separation between two coordinates
-    Uses Vicenty Formula (http://en.wikipedia.org/wiki/Great-circle_distance) and adapts from astropy's SkyCoord
-    Written to be used within the Database.cone_search() method and adapted from the original astrodbkit implementation
-
-    Parameters
-    ----------
-    row: dict, pandas Row
-        Coordinate structure containing ra and dec keys in decimal degrees
-    ra1: float
-        RA to compare with, in decimal degrees
-    dec1: float
-        Dec to compare with, in decimal degrees
-
-    Returns
-    -------
-        Angular distance, in degrees, between the coordinates
-    """
-
-    factor = np.pi / 180
-    sdlon = np.sin((row['ra'] - ra1) * factor)  # RA is longitude
-    cdlon = np.cos((row['ra'] - ra1) * factor)
-    slat1 = np.sin(dec1 * factor)  # Dec is latitude
-    slat2 = np.sin(row['dec'] * factor)
-    clat1 = np.cos(dec1 * factor)
-    clat2 = np.cos(row['dec'] * factor)
-
-    num1 = clat2 * sdlon
-    num2 = clat1 * slat2 - slat1 * clat2 * cdlon
-    numerator = np.sqrt(num1 ** 2 + num2 ** 2)
-    denominator = slat1 * slat2 + clat1 * clat2 * cdlon
-
-    return np.arctan2(numerator, denominator) / factor

--- a/astrodbkit2/utils.py
+++ b/astrodbkit2/utils.py
@@ -1,13 +1,14 @@
 # Utility functions for Astrodbkit2
 
 import re
+import numpy as np
 import functools
 import warnings
 from datetime import datetime
 from decimal import Decimal
 from astroquery.simbad import Simbad
 
-__all__ = ['json_serializer', 'get_simbad_names']
+__all__ = ['json_serializer', 'get_simbad_names', 'angular_separation']
 
 
 def deprecated_alias(**aliases):
@@ -120,3 +121,39 @@ def get_simbad_names(name):
     else:
         print(f'No Simbad match for {name}')
         return [name]
+
+
+def angular_separation(row, ra1, dec1):
+    """
+    Calculate angular separation between two coordinates
+    Uses Vicenty Formula (http://en.wikipedia.org/wiki/Great-circle_distance) and adapts from astropy's SkyCoord
+    Written to be used within the Database.cone_search() method and adapted from the original astrodbkit implementation
+
+    Parameters
+    ----------
+    row: dict, pandas Row
+        Coordinate structure containing ra and dec keys in decimal degrees
+    ra1: float
+        RA to compare with, in decimal degrees
+    dec1: float
+        Dec to compare with, in decimal degrees
+
+    Returns
+    -------
+        Angular distance, in degrees, between the coordinates
+    """
+
+    factor = np.pi / 180
+    sdlon = np.sin((row['ra'] - ra1) * factor)  # RA is longitude
+    cdlon = np.cos((row['ra'] - ra1) * factor)
+    slat1 = np.sin(dec1 * factor)  # Dec is latitude
+    slat2 = np.sin(row['dec'] * factor)
+    clat1 = np.cos(dec1 * factor)
+    clat2 = np.cos(row['dec'] * factor)
+
+    num1 = clat2 * sdlon
+    num2 = clat1 * slat2 - slat1 * clat2 * cdlon
+    numerator = np.sqrt(num1 ** 2 + num2 ** 2)
+    denominator = slat1 * slat2 + clat1 * clat2 * cdlon
+
+    return np.arctan2(numerator, denominator) / factor

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -196,20 +196,21 @@ The pretty_print parameter can be passed to print out results to the screen in a
         ]
     }
 
-Cone (spatial) Search
-~~~~~~~~~~~~~~~~~~~~~
+Region (spatial) Search
+~~~~~~~~~~~~~~~~~~~~~~~
 
-Another query method available in **Astrodbkit2**  is :py:meth:`~astrodbkit2.astrodb.Database.cone_search`.
-This performs a search around a given ra/dec location for sources in the database with a radius specified in arcseconds::
+Another query method available in **Astrodbkit2**  is :py:meth:`~astrodbkit2.astrodb.Database.query_region`.
+This performs a cone search around a given location for sources in the database.
+It expects astropy SkyCoord and Quantity objects for the position and radius::
 
-    db.cone_search(ra=209.301675, dec=14.477722, radius=60.)
+    db.query_region(SkyCoord(209.301675, 14.477722, frame='icrs', unit='deg'), radius=Quantity(60., unit='arcsec'))
 
 Similar to :py:meth:`~astrodbkit2.astrodb.Database.search_object`, a variety of options can be passed to control the output.
 If the table with coordinate information is not the primary table, it can be specifed as well::
 
-    db.cone_search(ra=209., dec=14., radius=60., output_table='Photometry')  # returning Photometry results for this search
-    db.cone_search(ra=209., dec=14., radius=60., fmt='pandas')  # returning as a pandas DataFrame
-    db.cone_search(ra=209., dec=14., radius=60., coordinate_table='Sources', ra_col='ra', dec_col='dec')  # specifying the name of the table with coordinate information
+    db.query_region(SkyCoord(209., 14., frame='icrs', unit='deg'), output_table='Photometry')  # returning Photometry results for this search
+    db.query_region(SkyCoord(209., 14., frame='icrs', unit='deg'), fmt='pandas')  # returning as a pandas DataFrame
+    db.query_region(SkyCoord(209., 14., frame='icrs', unit='deg'), coordinate_table='Sources', ra_col='ra', dec_col='dec')  # specifying the name of the table with coordinate information
 
 General Queries
 --------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,6 +129,9 @@ And users can also examine column information for an existing table::
 Specialized Searches
 --------------------
 
+Identifier (name) Search
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 To search for an object by name, users can use the :py:meth:`~astrodbkit2.astrodb.Database.search_object`
 method to do fuzzy searches on the provided name, output results from any table,
 and also include alternate Simbad names for their source. Refer to the API documentation for full details.
@@ -144,6 +147,9 @@ Search for TWA 27 and any of its alternate designations from Simbad and return r
 Search for any source with 1357+1428 in its name and return results from the Photometry table in pandas Dataframe format::
 
     db.search_object('1357+1428', output_table='Photometry', fmt='astropy')
+
+Inventory Search
+~~~~~~~~~~~~~~~~
 
 **Astrodbkit2**  also contains an :py:meth:`~astrodbkit2.astrodb.Database.inventory` method to return all data for a source by its name::
 
@@ -189,6 +195,9 @@ The pretty_print parameter can be passed to print out results to the screen in a
             ...
         ]
     }
+
+Cone (spatial) Search
+~~~~~~~~~~~~~~~~~~~~~
 
 Another query method available in **Astrodbkit2**  is :py:meth:`~astrodbkit2.astrodb.Database.cone_search`.
 This performs a search around a given ra/dec location for sources in the database with a radius specified in arcseconds::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -190,6 +190,18 @@ The pretty_print parameter can be passed to print out results to the screen in a
         ]
     }
 
+Another query method available in **Astrodbkit2**  is :py:meth:`~astrodbkit2.astrodb.Database.cone_search`.
+This performs a search around a given ra/dec location for sources in the database with a radius specified in arcseconds::
+
+    db.cone_search(ra=209.301675, dec=14.477722, radius=60.)
+
+Similar to :py:meth:`~astrodbkit2.astrodb.Database.search_object`, a variety of options can be passed to control the output.
+If the table with coordinate information is not the primary table, it can be specifed as well::
+
+    db.cone_search(ra=209., dec=14., radius=60., output_table='Photometry')  # returning Photometry results for this search
+    db.cone_search(ra=209., dec=14., radius=60., fmt='pandas')  # returning as a pandas DataFrame
+    db.cone_search(ra=209., dec=14., radius=60., coordinate_table='Sources', ra_col='ra', dec_col='dec')  # specifying the name of the table with coordinate information
+
 General Queries
 --------------------
 


### PR DESCRIPTION
This adds a new method to the database handler, `cone_search`, that takes in ra/dec/radius and will return matches to that.
Also sets the default output of `search_object` to be Astropy Tables, similar to `cone_search`.

Closes #3