### PR TITLE
Add serializer for bytes objects

### DIFF
--- a/astrodbkit2/tests/test_utils.py
+++ b/astrodbkit2/tests/test_utils.py
@@ -26,7 +26,8 @@ def test_name_formatter(test_input, expected):
 def test_json_serializer():
     data = {'date': datetime(2018, 12, 6, 12, 30, 0),
             'value': Decimal(2.3),
-            'integer': 4}
+            'integer': 4,
+            'bytes': b'byte'}
 
     json_text = json.dumps(data, indent=4, default=json_serializer)
     with StringIO(json_text) as f:
@@ -35,6 +36,7 @@ def test_json_serializer():
     assert new_data['date'] == '2018-12-06T12:30:00'
     assert new_data['value'] == pytest.approx(2.3)
     assert new_data['integer'] == 4
+    assert new_data['bytes'] == 'byte'
 
 
 def test_datetime_json_parser():

--- a/astrodbkit2/utils.py
+++ b/astrodbkit2/utils.py
@@ -50,6 +50,9 @@ def json_serializer(obj):
     if isinstance(obj, Decimal):
         return float(obj)
 
+    if isinstance(obj, bytes):
+        return obj.decode('utf-8')
+
     return obj.__dict__
 
 


### PR DESCRIPTION
This fixes issue #42 

With the example binary sqlite file I was able to confirm that calls like `x = db.inventory('2MASS J00061617+182110499', pretty_print=True)` fail without this change, but succeed afterwards (and correctly convert the stored byte as a string)