### PR TITLE
Generic string search

### DIFF
--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.query import Query
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.engine import Engine
-from sqlalchemy.types import String, Text, Unicode
+import sqlalchemy.types as sqlalchemy_types
 from sqlalchemy import event, create_engine, Table
 from sqlalchemy import or_, and_
 import sqlite3
@@ -540,9 +540,9 @@ class Database:
             # Gather only string-type columns
             columns = self.metadata.tables[table].columns
             col_list = [c for c in columns
-                        if isinstance(c.type, String)
-                        or isinstance(c.type, Text)
-                        or isinstance(c.type, Unicode)]
+                        if isinstance(c.type, sqlalchemy_types.String)
+                        or isinstance(c.type, sqlalchemy_types.Text)
+                        or isinstance(c.type, sqlalchemy_types.Unicode)]
 
             # Construct filters to query for each string column
             filters = []

--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.query import Query
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.engine import Engine
+from sqlalchemy.types import String, Text, Unicode
 from sqlalchemy import event, create_engine, Table
 from sqlalchemy import or_, and_
 import sqlite3
@@ -512,6 +513,60 @@ class Database:
         results = self._handle_format(temp, fmt)
 
         return results
+
+    def search_string(self, value, fmt='table', fuzzy_search=True, verbose=True):
+        """
+        Search an abitrary string across all string columns in the full database
+
+        Parameters
+        ----------
+        value : str
+            String to search for
+        fmt : str
+            Format to return results in (pandas, astropy/table, default). Default is astropy table
+        fuzzy_search : bool
+            Flag to perform partial searches on provided names (default: True)
+        verbose : bool
+            Output results to screen in addition to dictionary (default: True)
+
+        Returns
+        -------
+        Dictionary of results, with each key being the matched table names
+        """
+
+        # Loop over all tables to build the results
+        output_dict = {}
+        for table in self.metadata.tables:
+            # Gather only string-type columns
+            columns = self.metadata.tables[table].columns
+            col_list = [c for c in columns
+                        if isinstance(c.type, String)
+                        or isinstance(c.type, Text)
+                        or isinstance(c.type, Unicode)]
+
+            # Construct filters to query for each string column
+            filters = []
+            for c in col_list:
+                if fuzzy_search:
+                    filters += [c.ilike(f'%{value}%')]
+                else:
+                    filters += [c.ilike(f'{value}')]
+
+            # Perform the actual query
+            temp = self.query(self.metadata.tables[table]). \
+                filter(or_(*filters)). \
+                distinct(). \
+                all()
+
+            # Append results to dictionary output in specified format
+            if len(temp) > 0:
+                results = self._handle_format(temp, fmt)
+                if verbose:
+                    print(table)
+                    print(results)
+                output_dict[table] = results
+
+        return output_dict
 
     # General query methods
     @deprecated_alias(format='fmt')

--- a/astrodbkit2/tests/test_astrodb.py
+++ b/astrodbkit2/tests/test_astrodb.py
@@ -187,6 +187,14 @@ def test_search_object(mock_simbad, db):
         t = db.search_object('fake', table_names={'NOTABLE': ['nocolumn']})
 
 
+def test_search_string(db):
+    d = db.search_string('fake')
+    assert len(d['Sources']) > 0
+    assert d['Sources']['source'] == 'FAKE'
+    d = db.search_string('2mass', fuzzy_search=True)
+    assert len(d) > 0
+
+
 def test_query_region(db):
     t = db.query_region(SkyCoord(0, 0, frame='icrs', unit='deg'))
     assert len(t) == 0, 'Found source around 0,0 when there should be none'

--- a/astrodbkit2/tests/test_astrodb.py
+++ b/astrodbkit2/tests/test_astrodb.py
@@ -193,6 +193,8 @@ def test_search_string(db):
     assert d['Sources']['source'] == 'FAKE'
     d = db.search_string('2mass', fuzzy_search=True)
     assert len(d) > 0
+    d = db.search_string('2mass', fuzzy_search=False)
+    assert len(d) == 0
 
 
 def test_query_region(db):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -233,6 +233,18 @@ If the table with coordinate information is not the primary table, it can be spe
     db.query_region(SkyCoord(209., 14., frame='icrs', unit='deg'), fmt='pandas')  # returning as a pandas DataFrame
     db.query_region(SkyCoord(209., 14., frame='icrs', unit='deg'), coordinate_table='Sources', ra_col='ra', dec_col='dec')  # specifying the name of the table with coordinate information
 
+Full String Search
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Similar to the Identifier Search above, one can perform a case-insensitive search for
+any string against every string column in the database with :py:meth:`~astrodbkit2.astrodb.Database.search_string`.
+The output is a dictionary with keys for each table that matched results.
+This can be useful to find all results matching a particular reference regardless of table::
+
+    db.search_string('twa')  # search for any records with 'twa' anywhere in the database
+    db.search_string('Cruz18', fuzzy_search=False)  # search for strings exactly matching Cruz19 anywhere in the database
+    db.search_string('Cruz18', fuzzy_search=False, fmt='pandas')  # as above, but have each table as a pandas dataframe
+
 General Queries
 --------------------
 


### PR DESCRIPTION
This is a generic string search against every table in the database. It can be useful for finding every instance of a reference, or doing wildcard-type searches for similarly named object. It returns a dictionary with every matched table.
Example use:
```
db.search_string('twa') 
db.search_string('Cruz18', fuzzy_search=False)
db.search_string('Cruz18', fuzzy_search=False, fmt='pandas')
```