### PR TITLE
Implementing wcs1d-multispec

### DIFF
--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -235,7 +235,7 @@ def copy_database_schema(source_connection_string, destination_connection_string
 
         # Copy schema and create newTable from oldTable
         for column in src_metadata.tables[table.name].columns:
-            dest_table.append_column(column.copy())
+            dest_table.append_column(column._copy())
         dest_table.create()
 
         # Copy data, row by row

--- a/astrodbkit2/spectra.py
+++ b/astrodbkit2/spectra.py
@@ -78,17 +78,16 @@ def identify_wcs1d_multispec(origin, *args, **kwargs):
     """
     hdu = kwargs.get('hdu', 0)
 
-    # TODO: Expand checks, this is too ambigious and matches also iraf
-
     # Check if number of axes is one and dimension of WCS is greater than one
     with read_fileobj_or_hdulist(*args, **kwargs) as hdulist:
         return (hdulist[hdu].header.get('WCSDIM', 1) > 1 and
-                (hdulist[hdu].header['NAXIS'] > 1 or
-                 hdulist[hdu].header.get('WCSAXES', 0) > 1 ) and 
-                'WAT0_001' in hdulist[hdu].header)
+                hdulist[hdu].header['NAXIS'] > 1  and 
+                'WAT0_001' in hdulist[hdu].header and
+                hdulist[hdu].header.get('WCSDIM', 1) == hdulist[hdu].header['NAXIS'] and
+                'LINEAR' in hdulist[hdu].header.get('CTYPE1', ''))
 
 
-@data_loader("wcs1d-multispec", identifier=identify_wcs1d_multispec, extensions=['fits'], dtype=Spectrum1D)
+@data_loader("wcs1d-multispec", identifier=identify_wcs1d_multispec, extensions=['fits'], dtype=Spectrum1D, priority=10)
 def wcs1d_multispec_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
                       hdu=0, verbose=False, **kwargs):
     """

--- a/astrodbkit2/spectra.py
+++ b/astrodbkit2/spectra.py
@@ -153,7 +153,10 @@ def wcs1d_multispec_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
     wcs.unit = tuple(wcs.wcs.cunit)
 
     # Identify the correct parts of the data to store
-    flux_data = data[0]
+    if len(data.shape) > 1:
+        flux_data = data[0]
+    else:
+        flux_data = data
     uncertainty = None
     if 'NAXIS3' in header:
         for i in range(header['NAXIS3']):
@@ -163,8 +166,7 @@ def wcs1d_multispec_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
                 uncertainty = StdDevUncertainty(data[i])
 
     # Manually generate spectral axis
-    wcs_size = len(wcs.pixel_shape)
-    pixels = [[i] + [0]*(wcs_size-1) for i in range(wcs.pixel_shape[0])]
+    pixels = [[i] + [0]*(wcs.naxis-1) for i in range(wcs.pixel_shape[0])]
     spectral_axis = [i[0] for i in wcs.all_pix2world(pixels, 0)] * wcs.wcs.cunit[0]
 
     # Store header as metadata information

--- a/astrodbkit2/spectra.py
+++ b/astrodbkit2/spectra.py
@@ -127,6 +127,8 @@ def wcs1d_multispec_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
         # Load data, convert units if BUNIT and flux_unit is provided and not the same
         if 'BUNIT' in header:
             data = u.Quantity(hdulist[hdu].data, unit=header['BUNIT'])
+            if u.A in data.unit.bases:
+                data = data * u.A/u.AA # convert ampere to Angroms
             if flux_unit is not None:
                 data = data.to(flux_unit)
         else:

--- a/astrodbkit2/spectra.py
+++ b/astrodbkit2/spectra.py
@@ -88,7 +88,7 @@ def identify_wcs1d_multispec(origin, *args, **kwargs):
 
 
 @data_loader("wcs1d-multispec", identifier=identify_wcs1d_multispec, extensions=['fits'], dtype=Spectrum1D, priority=10)
-def wcs1d_multispec_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
+def wcs1d_multispec_loader(file_obj, flux_unit=None,
                       hdu=0, verbose=False, **kwargs):
     """
     Loader for multiextension spectra as wcs1d. Adapted from wcs1d_fits_loader
@@ -98,12 +98,6 @@ def wcs1d_multispec_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
     file_obj : str, file-like or HDUList
         FITS file name, object (provided from name by Astropy I/O Registry),
         or HDUList (as resulting from astropy.io.fits.open()).
-    spectral_axis_unit : :class:`~astropy.units.Unit` or str, optional
-        Units of the spectral axis. If not given (or None), the unit will be
-        inferred from the CUNIT in the WCS. Note that if this is provided it
-        will *override* any units the CUNIT specifies.
-        The WCS CUNIT will be obtained by default from the header CUNIT1 card;
-        if missing, the loader will try to extract it from the WAT1_001 card.
     flux_unit : :class:`~astropy.units.Unit` or str, optional
         Units of the flux for this spectrum. If not given (or None), the unit
         will be inferred from the BUNIT keyword in the header. Note that this
@@ -134,9 +128,7 @@ def wcs1d_multispec_loader(file_obj, spectral_axis_unit=None, flux_unit=None,
         else:
             data = u.Quantity(hdulist[hdu].data, unit=flux_unit)
 
-    if spectral_axis_unit is not None:
-        wcs.wcs.cunit[0] = str(spectral_axis_unit)
-    elif wcs.wcs.cunit[0] == '' and 'WAT1_001' in header:
+    if wcs.wcs.cunit[0] == '' and 'WAT1_001' in header:
         # Try to extract from IRAF-style card or use Angstrom as default.
         wat_dict = dict((rec.split('=') for rec in header['WAT1_001'].split()))
         unit = wat_dict.get('units', 'Angstrom')

--- a/astrodbkit2/tests/test_spectra.py
+++ b/astrodbkit2/tests/test_spectra.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from astropy.io import fits
 from astropy.units import Unit
-from astrodbkit2.spectra import identify_spex_prism, _identify_spex, load_spectrum, load_spex_prism
+from astrodbkit2.spectra import identify_spex_prism, _identify_spex, load_spectrum, spex_prism_loader
 try:
     import mock
 except ImportError:
@@ -58,11 +58,11 @@ def test_identify_spex(mock_fits_open, good_spex_file, bad_spex_file):
 def test_load_spex_prism(mock_fits_open, good_spex_file, bad_spex_file):
     # Test good example
     mock_fits_open.return_value = good_spex_file
-    spectrum = load_spex_prism('filename')
+    spectrum = spex_prism_loader('filename')
     assert spectrum.unit == Unit('erg / (A cm2 s)')
     # Test bad example
     mock_fits_open.return_value = bad_spex_file
-    spectrum = load_spex_prism('filename')
+    spectrum = spex_prism_loader('filename')
     assert spectrum.unit == Unit('erg')
 
 

--- a/astrodbkit2/tests/test_spectra.py
+++ b/astrodbkit2/tests/test_spectra.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from astropy.io import fits
 from astropy.units import Unit
-from astrodbkit2.spectra import identify_spex_prism, _identify_spex, load_spectrum, spex_prism_loader
+from astrodbkit2.spectra import identify_spex_prism, _identify_spex, load_spectrum, spex_prism_loader, identify_wcs1d_multispec, wcs1d_multispec_loader
 try:
     import mock
 except ImportError:
@@ -32,6 +32,25 @@ def bad_spex_file():
     hdr['INSTRUME'] = 'MISSING'
     hdr['GRAT'] = 'MISSING'
     hdr['XUNITS'] = 'UNKNOWN'
+    hdu1 = fits.PrimaryHDU(n, header=hdr)
+    return fits.HDUList([hdu1])
+
+
+@pytest.fixture(scope="module")
+def good_wcs1dmultispec():
+    n = np.empty((2141, 1, 4))
+    hdr = fits.Header()
+    hdr['WCSDIM'] = 3
+    hdr['NAXIS'] = 3
+    hdr['WAT0_001'] = 'system=equispec'
+    hdr['WAT1_001'] = 'wtype=linear label=Wavelength units=angstroms'
+    hdr['WAT2_001'] = 'wtype=linear'
+    hdr['BANDID1'] = 'spectrum - background fit, weights variance, clean no'               
+    hdr['BANDID2'] = 'raw - background fit, weights none, clean no'                        
+    hdr['BANDID3'] = 'background - background fit'                                         
+    hdr['BANDID4'] = 'sigma - background fit, weights variance, clean no'  
+    hdr['CTYPE1'] = 'LINEAR  '
+    hdr['BUNIT']   = 'erg/cm2/s/A'
     hdu1 = fits.PrimaryHDU(n, header=hdr)
     return fits.HDUList([hdu1])
 
@@ -64,6 +83,23 @@ def test_load_spex_prism(mock_fits_open, good_spex_file, bad_spex_file):
     mock_fits_open.return_value = bad_spex_file
     spectrum = spex_prism_loader('filename')
     assert spectrum.unit == Unit('erg')
+
+
+@mock.patch('astrodbkit2.spectra.read_fileobj_or_hdulist')
+def test_identify_wcs1d_multispec(mock_fits_open, good_wcs1dmultispec):
+    mock_fits_open.return_value = good_wcs1dmultispec
+
+    filename = 'https://s3.amazonaws.com/bdnyc/optical_spectra/U10929.fits'
+    assert identify_wcs1d_multispec('read', filename)
+
+
+@mock.patch('astrodbkit2.spectra.read_fileobj_or_hdulist')
+def test_wcs1d_multispec_loader(mock_fits_open, good_wcs1dmultispec):
+    mock_fits_open.return_value = good_wcs1dmultispec
+
+    spectrum = wcs1d_multispec_loader('filename')
+    assert spectrum.unit == Unit('erg / (A cm2 s)')
+    assert spectrum.wavelength.unit == Unit('Angstrom')
 
 
 @mock.patch('astrodbkit2.spectra.Spectrum1D.read')

--- a/astrodbkit2/tests/test_spectra.py
+++ b/astrodbkit2/tests/test_spectra.py
@@ -98,7 +98,7 @@ def test_wcs1d_multispec_loader(mock_fits_open, good_wcs1dmultispec):
     mock_fits_open.return_value = good_wcs1dmultispec
 
     spectrum = wcs1d_multispec_loader('filename')
-    assert spectrum.unit == Unit('erg / (A cm2 s)')
+    assert spectrum.unit == Unit('erg / (Angstrom cm2 s)')
     assert spectrum.wavelength.unit == Unit('Angstrom')
 
 

--- a/astrodbkit2/tests/test_spectra.py
+++ b/astrodbkit2/tests/test_spectra.py
@@ -56,7 +56,7 @@ def good_wcs1dmultispec():
 
 @pytest.fixture(scope="module")
 def alt_wcs1dmultispec():
-    n = np.empty((2141, 1, 4))
+    n = np.empty((2141,))
     hdr = fits.Header()
     hdr['WCSDIM'] = 1
     hdr['NAXIS'] = 1


### PR DESCRIPTION
This is an implementation of a loader that appears to work for some of the example multispectra that we've been having issues with. These files unfortunately match both the iraf and wcs1d-multispec identifiers, which may mean the `specutils` iraf identifier is too broad (and thus not something I can easily change). However, there is a `priority` parameter for the loader and while it's not well documented, setting it to a high value I was able to get the example spectra to load as a `Spectrum1D` object. Have a look and test it out, including for additional examples, and see if it works well.

Closes #52 