### PR TITLE
Spectra conversion updates

### DIFF
--- a/astrodbkit2/astrodb.py
+++ b/astrodbkit2/astrodb.py
@@ -108,7 +108,7 @@ class AstrodbQuery(Query):
 
         return df
 
-    def spectra(self, spectra=['spectrum'], fmt='astropy', **kwargs):
+    def spectra(self, spectra=['spectrum', 'access_url'], fmt='astropy', **kwargs):
         """
         Convenience method fo that uses default column name for spectra conversion
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -389,6 +389,7 @@ Reference/API
 
    astrodb.rst
    utils.rst
+   spectra.rst
 
 Indices and tables
 

--- a/docs/spectra.rst
+++ b/docs/spectra.rst
@@ -1,0 +1,8 @@
+spectra module
+==============
+
+.. automodule:: astrodbkit2.spectra
+   :members:
+   :ignore-module-all:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This updates the default columns to use in astrodbkit2 to run the conversion on. Both `spectrum` and `access_url` will be converted to a Spectrum1D object.

Closes #57